### PR TITLE
feat: 프로젝트 초기 환경 설정 및 엔티티 설계 반영

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.{js,html,css,yml,yaml}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,101 +1,69 @@
-<<<<<<< HEAD
-HELP.md
-.gradle
-build/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
-
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
-
-### IntelliJ IDEA ###
-.idea
-*.iws
-*.iml
-*.ipr
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
-
-### VS Code ###
-.vscode/
-=======
-# Compiled class file
+### Java & Spring Boot ###
 *.class
-
-# Log file
 *.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
 *.jar
 *.war
-*.nar
 *.ear
 *.zip
 *.tar.gz
 *.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# 빌드 결과물
+build/
+out/
+target/
+bin/
+.gradle/
 
 ### IntelliJ IDEA ###
 .idea/
 *.iml
-*.ipr
 *.iws
-out/             # 추가: 인텔리제이 빌드 결과물
+*.ipr
+atlassian-ide-plugin.xml
+com_zeroturnaround_jrebel_remoting_xml_state
 
-### OS ###
-.DS_Store
-Thumbs.db
+### VS Code ###
+.vscode/
+.history/
+*.code-workspace
 
-### Logs ###
-*.log
-
-### Spring Environment ###
-.env
-application-local.yml
-application-dev.yml
-application-test.yml
-# 중요: 실제 운영용 설정파일도 로컬에서 관리한다면 추가
-application-prod.yml 
-
-### Build Tools (필수 추가) ###
-build/           # Gradle 빌드 결과물
-target/          # Maven 빌드 결과물
-.gradle/         # Gradle 설정 캐시
-bin/             # 컴파일된 바이너리
-
-### Frontend (Thymeleaf/JS 관련) ###
-node_modules/    # JS 라이브러리 사용 시
+### Frontend & Tools ###
+node_modules/
 .pnp/
 .pnp.js
+.prettierignore   # Prettier 제외 설정파일 (필요시)
 
-### Others ###
-*.zip
-*.tar.gz
->>>>>>> fa90e4f03654d5501b205cbce57fd048c73d69a4
+### OS (System files) ###
+.DS_Store
+.DS_Store?
+._*
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+### Environment & Secret (보안 중요) ###
+.env
+.env.local
+application.yaml
+
+### 추가 권장 사항 ###
+.classpath
+.project
+.settings/
+*.log
+logs/
+temp/
+# 팀원마다 다른 롬복 설정이나 인텔리제이 내부 캐시 방지
+.idea/libraries/
+.idea/modules.xml
+.idea/workspace.xml
+
+### VS Code ###
+.vscode/                 # VS Code 설정 폴더 전체 (가장 중요)
+.history/                # 로컬 수정 이력
+*.code-workspace         # 워크스페이스 설정 파일
+.vscode-test/            # VS Code 테스트 결과물
+.factorypath             # VS Code 관련 설정 파일

--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,33 @@
+# Getting Started
+
+### Reference Documentation
+For further reference, please consider the following sections:
+
+* [Official Gradle documentation](https://docs.gradle.org)
+* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/3.5.10/gradle-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.5.10/gradle-plugin/packaging-oci-image.html)
+* [Spring Web](https://docs.spring.io/spring-boot/3.5.10/reference/web/servlet.html)
+* [Spring Data JPA](https://docs.spring.io/spring-boot/3.5.10/reference/data/sql.html#data.sql.jpa-and-spring-data)
+* [Thymeleaf](https://docs.spring.io/spring-boot/3.5.10/reference/web/servlet.html#web.servlet.spring-mvc.template-engines)
+* [Validation](https://docs.spring.io/spring-boot/3.5.10/reference/io/validation.html)
+* [Spring Security](https://docs.spring.io/spring-boot/3.5.10/reference/web/spring-security.html)
+
+### Guides
+The following guides illustrate how to use some features concretely:
+
+* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
+* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
+* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
+* [Accessing Data with JPA](https://spring.io/guides/gs/accessing-data-jpa/)
+* [Handling Form Submission](https://spring.io/guides/gs/handling-form-submission/)
+* [Accessing data with MySQL](https://spring.io/guides/gs/accessing-data-mysql/)
+* [Validation](https://spring.io/guides/gs/validating-form-input/)
+* [Securing a Web Application](https://spring.io/guides/gs/securing-web/)
+* [Spring Boot and OAuth2](https://spring.io/guides/tutorials/spring-boot-oauth2/)
+* [Authenticating a User with LDAP](https://spring.io/guides/gs/authenticating-ldap/)
+
+### Additional Links
+These additional references should also help you:
+
+* [Gradle Build Scans – insights for your project's build](https://scans.gradle.com#gradle)
+

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/encore/encore/EncoreApplication.java
+++ b/src/main/java/com/encore/encore/EncoreApplication.java
@@ -2,7 +2,9 @@ package com.encore.encore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class EncoreApplication {
 

--- a/src/main/java/com/encore/encore/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/encore/encore/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,30 @@
+package com.encore.encore.domain.chat.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long messageId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+    @Column(nullable = false)
+    private String content;
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/encore/encore/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/encore/encore/domain/chat/entity/ChatParticipant.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.chat.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_participant")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatParticipant extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long participantId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom room;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String participantStatus;
+}

--- a/src/main/java/com/encore/encore/domain/chat/entity/ChatPost.java
+++ b/src/main/java/com/encore/encore/domain/chat/entity/ChatPost.java
@@ -1,0 +1,38 @@
+package com.encore.encore.domain.chat.entity;
+
+import com.encore.encore.domain.member.entity.HostProfile;
+import com.encore.encore.domain.member.entity.PerformerProfile;
+import com.encore.encore.domain.member.entity.UserProfile;
+import com.encore.encore.domain.performance.entity.Performance;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatPost extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // String에서 Long으로 변경 권장 (IDENTITY 전략을 위해)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id")
+    private HostProfile host;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private UserProfile profile;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performer_id")
+    private PerformerProfile performer;
+    private String title;
+    private String content;
+    private Integer maxMember;
+    private String status;
+}

--- a/src/main/java/com/encore/encore/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/encore/encore/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,23 @@
+package com.encore.encore.domain.chat.entity;
+
+import com.encore.encore.domain.community.entity.Post;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoom extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+    private String roomType;
+}

--- a/src/main/java/com/encore/encore/domain/community/entity/Post.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/Post.java
@@ -1,0 +1,34 @@
+package com.encore.encore.domain.community.entity;
+
+import com.encore.encore.domain.member.entity.HostProfile;
+import com.encore.encore.domain.member.entity.PerformerProfile;
+import com.encore.encore.domain.performance.entity.Performance;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_author_id")
+    private HostProfile hostAuthor;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performer_author_id")
+    private PerformerProfile performerAuthor;
+    private String postType;
+    private String title;
+    private String content;
+    private Integer viewCount;
+}

--- a/src/main/java/com/encore/encore/domain/community/entity/PostInteraction.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/PostInteraction.java
@@ -1,0 +1,28 @@
+package com.encore.encore.domain.community.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "post_interaction")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostInteraction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long interactionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+    @Column(nullable = false)
+    private Long applicantPerformerId;
+    private Long targetPerformerId;
+    private Long senderPerformerId;
+    private String interactionType;
+    private String status;
+    private String message;
+}

--- a/src/main/java/com/encore/encore/domain/community/entity/Recommendation.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/Recommendation.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.community.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "recommendation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Recommendation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long recommendId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommender_id", nullable = false)
+    private User recommender;
+    private Integer rankNo;
+}

--- a/src/main/java/com/encore/encore/domain/community/entity/Report.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/Report.java
@@ -1,0 +1,28 @@
+package com.encore.encore.domain.community.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "report")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Report extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+    @Column(nullable = false)
+    private Long targetId;
+    @Column(nullable = false)
+    private String targetType;
+    private String reason;
+    private String status;
+}

--- a/src/main/java/com/encore/encore/domain/community/entity/Review.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/Review.java
@@ -1,0 +1,32 @@
+package com.encore.encore.domain.community.entity;
+
+import com.encore.encore.domain.performance.entity.Performance;
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.domain.venue.entity.Seat;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "review")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Review extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
+    private Integer rating;
+    private String content;
+}

--- a/src/main/java/com/encore/encore/domain/member/entity/HostProfile.java
+++ b/src/main/java/com/encore/encore/domain/member/entity/HostProfile.java
@@ -1,0 +1,25 @@
+package com.encore.encore.domain.member.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "host_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HostProfile extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hostId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String organizationName;
+    private String businessNumber;
+    private Boolean verified;
+}

--- a/src/main/java/com/encore/encore/domain/member/entity/PerformerProfile.java
+++ b/src/main/java/com/encore/encore/domain/member/entity/PerformerProfile.java
@@ -1,0 +1,27 @@
+package com.encore.encore.domain.member.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "performer_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PerformerProfile extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long performerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String stageName;
+    private String category;
+    private String description;
+    private Float rating;
+    private String skillLevel;
+}

--- a/src/main/java/com/encore/encore/domain/member/entity/UserProfile.java
+++ b/src/main/java/com/encore/encore/domain/member/entity/UserProfile.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.member.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "user_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfile extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long profileId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String profileImageUrl;
+    private String introduction;
+    private LocalDate birthDate;
+    private String phone;
+}

--- a/src/main/java/com/encore/encore/domain/performance/entity/Performance.java
+++ b/src/main/java/com/encore/encore/domain/performance/entity/Performance.java
@@ -1,0 +1,35 @@
+package com.encore.encore.domain.performance.entity;
+
+import com.encore.encore.domain.member.entity.HostProfile;
+import com.encore.encore.domain.member.entity.PerformerProfile;
+import com.encore.encore.domain.venue.entity.Venue;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "performance")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Performance extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long performanceId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id")
+    private Venue venue;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_creator_id")
+    private HostProfile hostCreator;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performer_creator_id")
+    private PerformerProfile performerCreator;
+    private String title;
+    private String description;
+    private String recruitStatus;
+    private Integer capacity;
+    private String status;
+}

--- a/src/main/java/com/encore/encore/domain/performance/entity/PerformancePerformer.java
+++ b/src/main/java/com/encore/encore/domain/performance/entity/PerformancePerformer.java
@@ -1,0 +1,33 @@
+package com.encore.encore.domain.performance.entity;
+
+import com.encore.encore.domain.member.entity.PerformerProfile;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "performance_performer")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PerformancePerformer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long performancePerformerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performer_id")
+    private PerformerProfile performer;
+    private Long artistProfileId;
+    private String role;
+    private LocalDateTime confirmedAt;
+    private Long applicantPerformerId;
+    private String status;
+    private Integer rankNo;
+}

--- a/src/main/java/com/encore/encore/domain/performance/entity/PerformanceSchedule.java
+++ b/src/main/java/com/encore/encore/domain/performance/entity/PerformanceSchedule.java
@@ -1,0 +1,25 @@
+package com.encore.encore.domain.performance.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "performance_schedule")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PerformanceSchedule extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long scheduleId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}

--- a/src/main/java/com/encore/encore/domain/performance/entity/UserPerformanceRelation.java
+++ b/src/main/java/com/encore/encore/domain/performance/entity/UserPerformanceRelation.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.performance.entity;
+
+import com.encore.encore.domain.user.entity.User;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_performance_relation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPerformanceRelation extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long relationId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "performance_id")
+    private Performance performance;
+    private String status;
+    @Column(nullable = false) private LocalDateTime watchedAt;
+}

--- a/src/main/java/com/encore/encore/domain/user/controller/HomeController.java
+++ b/src/main/java/com/encore/encore/domain/user/controller/HomeController.java
@@ -1,0 +1,17 @@
+package com.encore.encore.domain.user.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller // @RestController가 아닌 것에 주의하세요! (HTML 반환용)
+public class HomeController {
+
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("title", "ENCORE PROJECT");
+        model.addAttribute("message", "백엔드 서버가 성공적으로 실행되었습니다.");
+        model.addAttribute("leader", "팀장님");
+        return "index"; // index.html을 찾아서 띄웁니다.
+    }
+}

--- a/src/main/java/com/encore/encore/domain/user/entity/AuthLog.java
+++ b/src/main/java/com/encore/encore/domain/user/entity/AuthLog.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.user.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "auth_log")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long authId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String loginType;
+    private String loginIp;
+    private LocalDateTime lastLoginAt;
+}

--- a/src/main/java/com/encore/encore/domain/user/entity/EmailVerification.java
+++ b/src/main/java/com/encore/encore/domain/user/entity/EmailVerification.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.user.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_verification")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailVerification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long verificationId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private String code;
+    private LocalDateTime expiredAt;
+    private Boolean verified;
+}

--- a/src/main/java/com/encore/encore/domain/user/entity/User.java
+++ b/src/main/java/com/encore/encore/domain/user/entity/User.java
@@ -1,0 +1,27 @@
+package com.encore.encore.domain.user.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(nullable = false, unique = true)
+    private String email;
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+    @Column(nullable = false)
+    private String nickname;
+    @Column(nullable = false)
+    private String role;
+    private String status;
+}

--- a/src/main/java/com/encore/encore/domain/user/entity/UserNotification.java
+++ b/src/main/java/com/encore/encore/domain/user/entity/UserNotification.java
@@ -1,0 +1,23 @@
+package com.encore.encore.domain.user.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_notification")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserNotification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long settingId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    private Boolean performanceStartAlert;
+    private Boolean dmAlert;
+}

--- a/src/main/java/com/encore/encore/domain/user/entity/UserRelation.java
+++ b/src/main/java/com/encore/encore/domain/user/entity/UserRelation.java
@@ -1,0 +1,22 @@
+package com.encore.encore.domain.user.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_relation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserRelation extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long relationId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "actor_id", nullable = false)
+    private User actor;
+    private String relationType;
+    private String targetType;
+    private Long targetId;
+}

--- a/src/main/java/com/encore/encore/domain/venue/entity/Seat.java
+++ b/src/main/java/com/encore/encore/domain/venue/entity/Seat.java
@@ -1,0 +1,25 @@
+package com.encore.encore.domain.venue.entity;
+
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "seat")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Seat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seatId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id", nullable = false)
+    private Venue venue;
+    private Integer seatFloor;
+    private String seatSection;
+    private Integer seatNumber;
+    private String seatType;
+}

--- a/src/main/java/com/encore/encore/domain/venue/entity/Venue.java
+++ b/src/main/java/com/encore/encore/domain/venue/entity/Venue.java
@@ -1,0 +1,24 @@
+package com.encore.encore.domain.venue.entity;
+
+import com.encore.encore.domain.member.entity.HostProfile;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "venue")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Venue extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long venueId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "host_id", nullable = false)
+    private HostProfile host;
+    @Column(nullable = false) private String venueName;
+    @Column(nullable = false) private String address;
+    private String venueType;
+    private Integer totalSeats;
+}

--- a/src/main/java/com/encore/encore/domain/venue/entity/VenueReservation.java
+++ b/src/main/java/com/encore/encore/domain/venue/entity/VenueReservation.java
@@ -1,0 +1,30 @@
+package com.encore.encore.domain.venue.entity;
+
+import com.encore.encore.domain.member.entity.HostProfile;
+import com.encore.encore.domain.member.entity.PerformerProfile;
+import com.encore.encore.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "venue_reservation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VenueReservation extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reservationId;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "venue_id", nullable = false)
+    private Venue venue;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "host_id")
+    private HostProfile host;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "performer_id")
+    private PerformerProfile performer;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String status;
+}

--- a/src/main/java/com/encore/encore/global/common/BaseEntity.java
+++ b/src/main/java/com/encore/encore/global/common/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.encore.encore.global.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    // 논리 삭제 메서드
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/encore/encore/global/common/CommonResponse.java
+++ b/src/main/java/com/encore/encore/global/common/CommonResponse.java
@@ -1,0 +1,26 @@
+package com.encore.encore.global.common;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter // JSON으로 변환되려면 Getter가 필수입니다!
+public class CommonResponse<T> {
+    private final boolean success;
+    private final String message;
+    private final T data;
+    private final LocalDateTime timestamp;
+
+    private CommonResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // 성공 시 이 메서드만 씁니다!
+    public static <T> CommonResponse<T> ok(T data, String message) {
+        return new CommonResponse<>(true, message, data);
+    }
+}
+

--- a/src/main/java/com/encore/encore/global/config/SecurityConfig.java
+++ b/src/main/java/com/encore/encore/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.encore.encore.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            // 1. CSRF 보안 해제 (POST, PUT 테스트를 위해 필수)
+            .csrf(AbstractHttpConfigurer::disable)
+
+            // 2. CORS 허용 (프론트엔드 연결 대비)
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+            // 3. H2 Console 등 프레임 사용 허용
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+
+            // 4. 모든 요청 완전 허용 (인증 절차 생략)
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll() // 모든 요청(루트, API, Swagger 등)을 다 열어줌
+            );
+
+        return http.build();
+    }
+
+
+    // CORS 기본 설정: 모든 도메인 허용 (개발 단계용)
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/encore/encore/global/config/SwaggerConfig.java
+++ b/src/main/java/com/encore/encore/global/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.encore.encore.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Encore Project API")
+                .description("공연 매칭 플랫폼 API 명세서")
+                .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/encore/encore/global/error/ApiException.java
+++ b/src/main/java/com/encore/encore/global/error/ApiException.java
@@ -1,0 +1,18 @@
+package com.encore.encore.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ApiException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/encore/encore/global/error/ErrorCode.java
+++ b/src/main/java/com/encore/encore/global/error/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.encore.encore.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-500", "서버 오류입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-400", "요청이 올바르지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH-403", "권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-404", "대상을 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "COMMON-409", "요청이 충돌했습니다.");
+        
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/encore/encore/global/error/ErrorResponse.java
+++ b/src/main/java/com/encore/encore/global/error/ErrorResponse.java
@@ -1,0 +1,34 @@
+package com.encore.encore.global.error;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String code;
+    private final String message;
+    private final String path;
+    private final List<FieldError> fieldErrors;
+
+    public static ErrorResponse of(ErrorCode errorCode, String path, String message) {
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(message)
+                .path(path)
+                .build();
+    }
+
+    @Getter
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+    }
+}

--- a/src/main/java/com/encore/encore/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/encore/encore/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.encore.encore.global.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException e, HttpServletRequest request) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode, request.getRequestURI(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR, request.getRequestURI(), "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,58 @@
+server:
+  port: 8080 # 기본 포트지만 명시해주는 것이 정석
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
 spring:
   application:
     name: encore
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # 본인의 DB 명칭으로 수정하세요 (localhost:3306/DB명)
+    url: jdbc:mysql://localhost:3306/encore_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root # 본인 MySQL 비밀번호
+
+  jpa:
+    hibernate:
+      ddl-auto: update # 엔티티 수정 시 테이블 자동 반영
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger
+    display-request-duration: true
+  api-docs:
+    path: /api-docs
+
+# ... 기존 설정들 (server, spring, springdoc 등) 하단에 추가
+
+logging:
+  level:
+    root: info # 기본은 info 레벨로 깔끔하게
+    com.encore.encore: debug # 우리 팀이 짠 코드는 상세하게 기록 (버그 추적용)
+    org.hibernate.SQL: debug # 실행되는 SQL문을 콘솔에 출력
+    org.hibernate.type.descriptor.sql.BasicBinder: trace # 쿼리의 '?'에 들어가는 실제 값을 로그로 확인
+    org.springframework.web: info # 스프링 웹 관련 로그
+
+  pattern:
+    # 일본 현업 스타일: [시간] [로그레벨] [스레드] [클래스명] - 메시지 형식
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+
+  file:
+    # 프로젝트 루트 폴더의 logs 폴더 안에 'encore_project.log'로 자동 저장
+    name: logs/encore_project.log
+
+  logback:
+    rollingpolicy:
+      # 로그 파일이 너무 커지지 않게 관리 (10MB 넘으면 새로 만들고, 7일치만 보관)
+      max-file-size: 10MB
+      max-history: 7

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Encore Project</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background-color: #f8f9fa; height: 100vh; display: flex; align-items: center; justify-content: center; }
+    .card { border-radius: 15px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+  </style>
+</head>
+<body>
+<div class="card p-5 text-center">
+  <h1 class="display-4 text-primary fw-bold" th:text="${title}">Project Name</h1>
+  <p class="lead mt-3" th:text="${message}">Welcome message</p>
+  <hr>
+  <p class="text-muted">안녕하세요, <strong th:text="${leader}">Leader</strong>님!</p>
+  <div class="mt-4">
+    <a href="/swagger" class="btn btn-outline-primary btn-lg">API 문서 (Swagger) 바로가기</a>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📌 개요
프로젝트 시작을 위한 전체적인 백엔드 인프라와 도메인 모델 설계를 완료했습니다.

## 🛠️ 작업 사항
- **Entity**: 24개 엔티티 생성 및 공통 필드(`BaseEntity`) 적용
- **Config**: 
  - JPA Auditing 활성화
  - Swagger UI API 문서 자동화 세팅
  - Querydsl 설정 및 Security 완전 개방 (개발용)
- **UI**: 루트 경로(`/`) 타임리프 홈 화면 구현 및 접속 확인

## 🧪 테스트 결과
- 서버 기동 시 Hibernate 테이블 자동 생성 확인 (24개)
- `http://localhost:8080/` 접속 및 Swagger 정상 작동 확인

