### PR TITLE
2026-02-04, 공연장·공연 목록/상세 조회 API 구현, 이슈 #8 관련

### DIFF
--- a/src/main/java/com/encore/encore/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/encore/encore/domain/performance/controller/PerformanceController.java
@@ -1,0 +1,74 @@
+package com.encore.encore.domain.performance.controller;
+
+import com.encore.encore.domain.performance.dto.PerformanceDetailDto;
+import com.encore.encore.domain.performance.dto.PerformanceListItemDto;
+import com.encore.encore.domain.performance.service.PerformanceService;
+import com.encore.encore.global.common.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/performances")
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    /**
+     * 공연 목록을 조회 (검색/카테고리/페이징 지원)
+     * @param keyword 검색어(공연 제목 기준) - null/빈값 가능
+     * @param category 카테고리 - null/빈값 가능
+     * @param page 페이지 번호(0부터 시작)
+     * @param size 페이지 당 개수
+     * @return 공연 목록 페이지
+     */
+    @GetMapping
+    public CommonResponse<Page<PerformanceListItemDto>> getPerformances(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) String category,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "9") int size
+    ) {
+        log.info("[Performance] controller list - keyword={}, category={}, page={}, size={}", keyword, category, page, size);
+
+        return CommonResponse.ok(
+            performanceService.getPerformances(keyword, category, PageRequest.of(page, size)),
+            "공연 목록 조회 성공"
+        );
+    }
+
+    /**
+     * 공연 상세 정보를 조회
+     * @param performanceId 공연 ID
+     * @return 공연 상세 DTO
+     */
+    @GetMapping("/{performanceId}")
+    public CommonResponse<PerformanceDetailDto> getPerformance(@PathVariable Long performanceId) {
+        log.info("[Performance] controller detail - performanceId={}", performanceId);
+
+        return CommonResponse.ok(
+            performanceService.getPerformance(performanceId),
+            "공연 상세 조회 성공"
+        );
+    }
+
+    /**
+     * 핫한 공연 Top10을 조회 (캐러셀용)
+     * @return 핫한 공연 리스트
+     */
+    @GetMapping("/hot")
+    public CommonResponse<List<PerformanceListItemDto>> getHotPerformances() {
+        log.info("[Performance] controller hot list");
+
+        return CommonResponse.ok(
+            performanceService.getHotPerformances(),
+            "핫한 공연 조회 성공"
+        );
+    }
+}

--- a/src/main/java/com/encore/encore/domain/performance/dto/PerformanceDetailDto.java
+++ b/src/main/java/com/encore/encore/domain/performance/dto/PerformanceDetailDto.java
@@ -1,0 +1,22 @@
+package com.encore.encore.domain.performance.dto;
+
+import com.encore.encore.domain.performance.entity.Performance;
+import lombok.Getter;
+
+@Getter
+public class PerformanceDetailDto {
+
+    private final Long performanceId;
+    private final String title;
+    private final String description;
+    private final String status;
+    private final Integer capacity;
+
+    public PerformanceDetailDto(Performance performance) {
+        this.performanceId = performance.getPerformanceId();
+        this.title = performance.getTitle();
+        this.description = performance.getDescription();
+        this.status = performance.getStatus();
+        this.capacity = performance.getCapacity();
+    }
+}

--- a/src/main/java/com/encore/encore/domain/performance/dto/PerformanceListItemDto.java
+++ b/src/main/java/com/encore/encore/domain/performance/dto/PerformanceListItemDto.java
@@ -1,0 +1,20 @@
+package com.encore.encore.domain.performance.dto;
+
+import com.encore.encore.domain.performance.entity.Performance;
+import lombok.Getter;
+
+@Getter
+public class PerformanceListItemDto {
+
+    private final Long performanceId;
+    private final String title;
+    private final String status;
+    private final Integer capacity;
+
+    public PerformanceListItemDto(Performance performance) {
+        this.performanceId = performance.getPerformanceId();
+        this.title = performance.getTitle();
+        this.status = performance.getStatus();
+        this.capacity = performance.getCapacity();
+    }
+}

--- a/src/main/java/com/encore/encore/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/encore/encore/domain/performance/repository/PerformanceRepository.java
@@ -1,0 +1,43 @@
+package com.encore.encore.domain.performance.repository;
+
+import com.encore.encore.domain.performance.entity.Performance;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+
+    /**
+     * 제목 검색 (카테고리 전체일 때 사용)
+     * @param title 검색어(공연 제목)
+     * @param pageable 페이징 정보
+     * @return 검색된 공연 페이지
+     */
+    Page<Performance> findByTitleContainingIgnoreCase(String title, Pageable pageable);
+
+    /**
+     * 제목 + 카테고리(status) 검색
+     * @param title 검색어(공연 제목)
+     * @param status 카테고리
+     * @param pageable 페이징 정보
+     * @return 검색된 공연 페이지
+     */
+    Page<Performance> findByTitleContainingIgnoreCaseAndStatus(String title, String status, Pageable pageable);
+
+    /**
+     * 카테고리(status)만으로 조회
+     * @param status 카테고리
+     * @param pageable 페이징 정보
+     * @return 카테고리별 공연 페이지
+     */
+    Page<Performance> findByStatus(String status, Pageable pageable);
+
+    /**
+     * 핫한 공연 Top10 조회 (임시 기준 - createdAt 최신순)
+     * @param status 대상 상태(예: OPEN)
+     * @return 최신순 Top10 공연
+     */
+    List<Performance> findTop10ByStatusOrderByCreatedAtDesc(String status);
+}

--- a/src/main/java/com/encore/encore/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/encore/encore/domain/performance/service/PerformanceService.java
@@ -1,0 +1,107 @@
+package com.encore.encore.domain.performance.service;
+
+import com.encore.encore.domain.performance.dto.PerformanceDetailDto;
+import com.encore.encore.domain.performance.dto.PerformanceListItemDto;
+import com.encore.encore.domain.performance.entity.Performance;
+import com.encore.encore.domain.performance.repository.PerformanceRepository;
+import com.encore.encore.global.error.ApiException;
+import com.encore.encore.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PerformanceService {
+
+    private final PerformanceRepository performanceRepository;
+
+    /**
+     * 공연 목록 조회 (검색/카테고리/페이징 지원)
+     *
+     * - category가 "전체" 또는 비어 있으면 - 제목 검색만 적용하거나(검색어 있을 때), 전체 조회
+     * - category가 특정 값이면 status 필터를 적용하고, 검색어가 있으면 title도 함께 검색
+     *
+     * @param keyword 공연 제목 검색어(null/빈값 가능)
+     * @param category 카테고리(전체/밴드/뮤지컬/연극 등, null/빈값 가능)
+     * @param pageable 페이징 정보
+     * @return 공연 목록 페이지(리스트 DTO)
+     */
+    public Page<PerformanceListItemDto> getPerformances(String keyword, String category, Pageable pageable) {
+
+        boolean hasKeyword = StringUtils.hasText(keyword);
+        boolean hasCategory = StringUtils.hasText(category) && !"전체".equals(category);
+
+        log.info("[Performance] list request - keyword={}, category={}, page={}, size={}",
+            keyword,
+            category,
+            pageable.getPageNumber(),
+            pageable.getPageSize()
+        );
+
+        Page<Performance> performances;
+
+        // 경우의 수를 명확히 나눠야 "전체 + 검색" 같은 케이스에서 검색이 무시되는 버그를 막을 수 있음
+        if (hasCategory && hasKeyword) {
+            // 카테고리 + 검색어
+            performances = performanceRepository.findByTitleContainingIgnoreCaseAndStatus(keyword, category, pageable);
+        } else if (hasCategory) {
+            // 카테고리만
+            performances = performanceRepository.findByStatus(category, pageable);
+        } else if (hasKeyword) {
+            // 전체 + 검색어
+            performances = performanceRepository.findByTitleContainingIgnoreCase(keyword, pageable);
+        } else {
+            // 전체
+            performances = performanceRepository.findAll(pageable);
+        }
+
+        log.info("[Performance] list result - totalElements={}, totalPages={}",
+            performances.getTotalElements(),
+            performances.getTotalPages()
+        );
+
+        return performances.map(PerformanceListItemDto::new);
+    }
+
+    /**
+     * 공연 상세 정보를 조회. 대상이 없으면 NOT_FOUND 예외를 발생.
+     * @param performanceId 공연 ID
+     * @return 공연 상세 DTO
+     */
+    public PerformanceDetailDto getPerformance(Long performanceId) {
+        log.info("[Performance] detail request - performanceId={}", performanceId);
+
+        Performance performance = performanceRepository.findById(performanceId)
+            .orElseThrow(() -> new ApiException(
+                ErrorCode.NOT_FOUND,
+                "공연을 찾을 수 없습니다. performanceId=" + performanceId
+            ));
+
+        log.info("[Performance] detail found - performanceId={}", performanceId);
+        return new PerformanceDetailDto(performance);
+    }
+
+    /**
+     * 핫한 공연 Top10을 조회. (임시 기준 - OPEN 상태 + createdAt 최신순)
+     * @return 핫한 공연 리스트(리스트 DTO)
+     */
+    public List<PerformanceListItemDto> getHotPerformances() {
+        log.info("[Performance] hot list request - status=OPEN, limit=10");
+
+        List<PerformanceListItemDto> result = performanceRepository
+            .findTop10ByStatusOrderByCreatedAtDesc("OPEN")
+            .stream()
+            .map(PerformanceListItemDto::new)
+            .toList();
+
+        log.info("[Performance] hot list result - size={}", result.size());
+        return result;
+    }
+}

--- a/src/main/java/com/encore/encore/domain/venue/controller/VenueController.java
+++ b/src/main/java/com/encore/encore/domain/venue/controller/VenueController.java
@@ -1,0 +1,56 @@
+package com.encore.encore.domain.venue.controller;
+
+import com.encore.encore.domain.venue.dto.VenueDetailDto;
+import com.encore.encore.domain.venue.dto.VenueListItemDto;
+import com.encore.encore.domain.venue.service.VenueService;
+import com.encore.encore.global.common.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/venues")
+public class VenueController {
+
+    private final VenueService venueService;
+
+    /**
+     * 공연장 목록을 조회 (검색/페이징 지원)
+     * @param keyword 검색어(공연장명 또는 주소) - null/빈값이면 전체 조회
+     * @param page 페이지 번호(0부터 시작)
+     * @param size 페이지 당 개수
+     * @return 공연장 목록 페이지
+     */
+    @GetMapping
+    public CommonResponse<Page<VenueListItemDto>> getVenues(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        log.info("[Venue] list request - keyword={}, page={}, size={}", keyword, page, size); // [추가] INFO 로그
+
+        return CommonResponse.ok(
+            venueService.getVenues(keyword, PageRequest.of(page, size)),
+            "공연장 목록 조회 성공"
+        );
+    }
+
+    /**
+     * 공연장 상세 정보를 조회
+     * @param venueId 공연장 ID
+     * @return 공연장 상세 정보
+     */
+    @GetMapping("/{venueId}")
+    public CommonResponse<VenueDetailDto> getVenue(@PathVariable Long venueId) {
+        log.info("[Venue] detail request - venueId={}", venueId); // [추가] INFO 로그
+
+        return CommonResponse.ok(
+            venueService.getVenue(venueId),
+            "공연장 상세 조회 성공"
+        );
+    }
+}

--- a/src/main/java/com/encore/encore/domain/venue/dto/VenueDetailDto.java
+++ b/src/main/java/com/encore/encore/domain/venue/dto/VenueDetailDto.java
@@ -1,0 +1,22 @@
+package com.encore.encore.domain.venue.dto;
+
+import com.encore.encore.domain.venue.entity.Venue;
+import lombok.Getter;
+
+@Getter
+public class VenueDetailDto {
+
+    private final Long venueId;
+    private final String venueName;
+    private final String address;
+    private final String venueType;
+    private final Integer totalSeats;
+
+    public VenueDetailDto(Venue venue) {
+        this.venueId = venue.getVenueId();
+        this.venueName = venue.getVenueName();
+        this.address = venue.getAddress();
+        this.venueType = venue.getVenueType();
+        this.totalSeats = venue.getTotalSeats();
+    }
+}

--- a/src/main/java/com/encore/encore/domain/venue/dto/VenueListItemDto.java
+++ b/src/main/java/com/encore/encore/domain/venue/dto/VenueListItemDto.java
@@ -1,0 +1,21 @@
+package com.encore.encore.domain.venue.dto;
+
+import com.encore.encore.domain.venue.entity.Venue;
+import lombok.Getter;
+
+@Getter
+public class VenueListItemDto {
+    private final Long venueId;
+    private final String venueName;
+    private final String address;
+    private final String venueType;
+    private final Integer totalSeats;
+
+    public VenueListItemDto(Venue venue) {
+        this.venueId = venue.getVenueId();
+        this.venueName = venue.getVenueName();
+        this.address = venue.getAddress();
+        this.venueType = venue.getVenueType();
+        this.totalSeats = venue.getTotalSeats();
+    }
+}

--- a/src/main/java/com/encore/encore/domain/venue/repository/VenueRepository.java
+++ b/src/main/java/com/encore/encore/domain/venue/repository/VenueRepository.java
@@ -1,0 +1,15 @@
+package com.encore.encore.domain.venue.repository;
+
+import com.encore.encore.domain.venue.entity.Venue;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VenueRepository extends JpaRepository<Venue, Long> {
+
+    Page<Venue> findByVenueNameContainingIgnoreCaseOrAddressContainingIgnoreCase(
+        String venueName,
+        String address,
+        Pageable pageable
+    );
+}

--- a/src/main/java/com/encore/encore/domain/venue/service/VenueService.java
+++ b/src/main/java/com/encore/encore/domain/venue/service/VenueService.java
@@ -1,0 +1,54 @@
+package com.encore.encore.domain.venue.service;
+
+import com.encore.encore.domain.venue.dto.VenueDetailDto;
+import com.encore.encore.domain.venue.dto.VenueListItemDto;
+import com.encore.encore.domain.venue.entity.Venue;
+import com.encore.encore.domain.venue.repository.VenueRepository;
+import com.encore.encore.global.error.ApiException;
+import com.encore.encore.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VenueService {
+
+    private final VenueRepository venueRepository;
+
+    /**
+     * 공연장 목록을 조회. 검색어가 있으면 이름/주소 기준 검색, 없으면 전체 조회.
+     * @param keyword 검색어
+     * @param pageable 페이징 정보
+     * @return 공연장 목록(페이지)
+     */
+    public Page<VenueListItemDto> getVenues(String keyword, Pageable pageable) {
+
+        // 컨트롤러가 아니라 서비스에서 "검색/전체조회 분기"를 처리해야
+        // 다른 API에서도 재사용 가능하고, 컨트롤러가 얇아져 유지보수성이 좋아짐
+        Page<Venue> venues = StringUtils.hasText(keyword)
+            ? venueRepository.findByVenueNameContainingIgnoreCaseOrAddressContainingIgnoreCase(keyword, keyword, pageable)
+            : venueRepository.findAll(pageable);
+
+        log.info("[Venue] list result - keyword={}, totalElements={}", keyword, venues.getTotalElements());
+        return venues.map(VenueListItemDto::new);
+    }
+
+    /**
+     * 공연장 상세 정보를 조회. 대상이 없으면 NOT_FOUND 예외를 발생.
+     * @param venueId 공연장 ID
+     * @return 공연장 상세 DTO
+     */
+    public VenueDetailDto getVenue(Long venueId) {
+        Venue venue = venueRepository.findById(venueId)
+            // detailMessage까지 주면 사용자 메시지/로그 모두 더 명확해짐
+            .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "공연장을 찾을 수 없습니다. venueId=" + venueId));
+
+        log.info("[Venue] detail found - venueId={}", venueId);
+        return new VenueDetailDto(venue);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 공연장(Venue) 목록/상세 조회 API 구현
- 공연(Performance) 목록/상세 조회 API 구현
- 더미 데이터를 기반으로 조회 API 동작 확인
- Closes #8 

## ✅ 셀프 체크리스트

- [x]  브랜치 전략(feature -> develop)을 준수하였는가?
- [x]  커밋 메시지 컨벤션을 지켰는가? (yyyy-MM-dd, [변경내용])
- [x]  로그(SLF4J)를 적절히 사용하였는가? (System.out 금지)
- [x]  Public 메서드에 JavaDoc 주석을 작성하였는가?
- [x]  불필요한 공백이나 사용하지 않는 Import를 제거하였는가?

## 📸 스크린샷 / 결과 (선택)

- Postman을 통한 공연장/공연 조회 API 테스트 결과 확인

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/d8e3dbe5-14f9-481c-9a75-679655393080" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/ef40af0a-6f43-47e4-a3b2-50ccc046cb6a" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/99b31af5-0a7d-41e8-962a-db9bb4b94193" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/6575d4dd-a33a-4b7e-87b0-c70bcb56b8c7" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/d659004b-cb4f-4bb1-872c-19d855e2647b" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/f34a7c3d-b60d-474b-972b-d93dc164abb9" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/902f6d10-2df7-4f42-8df1-418646255bf9" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/1477aa34-3ea0-43c4-a1b7-d6621cd1ccef" />
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/d8ab27bc-4d4b-47da-8f35-cb50913e3735" />
