### PR TITLE
2026-02-05, 공연 목록 화면 구현 및 상세 화면 테스트용 임시 페이지 추가, 이슈 #14 관련

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ insert_final_newline = true
 end_of_line = lf
 
 [*.{js,html,css,yml,yaml}]
-indent_size = 2
+indent_size = 4

--- a/src/main/java/com/encore/encore/domain/performance/controller/PerformancePageController.java
+++ b/src/main/java/com/encore/encore/domain/performance/controller/PerformancePageController.java
@@ -1,0 +1,36 @@
+package com.encore.encore.domain.performance.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@Controller
+@RequestMapping("/performances")
+public class PerformancePageController {
+
+    /**
+     * 공연 목록 페이지 반환
+     * @return 공연 목록 화면 템플릿 경로
+     */
+    @GetMapping
+    public String listPage() {
+        log.info("[PerformancePage] list page requested");
+        return "performance/list";
+    }
+
+    /**
+     * 공연 상세 페이지 반환 (데이터는 JS에서 /api/performances/{id} 호출로 조회)
+     * @param performanceId 공연 ID
+     * @param model Thymeleaf 모델(화면에 performanceId 전달)
+     * @return 공연 상세 화면 템플릿 경로
+     */
+    @GetMapping("/{performanceId}")
+    public String detailPage(@PathVariable Long performanceId, Model model) {
+        log.info("[PerformancePage] detail page requested - performanceId={}", performanceId);
+
+        model.addAttribute("performanceId", performanceId);
+        return "performance/detail";
+    }
+}

--- a/src/main/resources/static/css/performance/list.css
+++ b/src/main/resources/static/css/performance/list.css
@@ -1,0 +1,76 @@
+html,
+body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+body {
+    background: #eaeaea;
+    display: flex;
+    justify-content: center;
+}
+
+.app-wrapper {
+    width: 100%;
+    max-width: 430px;
+    min-height: 100vh;
+    background: #ffffff;
+}
+
+.top-slot {
+    height: 24px;
+}
+
+.bottom-slot {
+    height: 24px;
+}
+
+.app-main {
+    padding: 16px;
+    box-sizing: border-box;
+}
+
+.hot-carousel-inner {
+    background: #dcdcdc;
+    border-radius: 8px;
+    height: 140px;
+    display: flex;
+    align-items: center;
+    padding-left: 18px;
+    box-sizing: border-box;
+}
+
+.hot-title {
+    font-size: 28px;
+    font-weight: 800;
+}
+
+.category-tabs {
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+}
+
+.tab-btn {
+    border: 0;
+    background: transparent;
+    padding: 6px 2px;
+    font-weight: 600;
+    white-space: nowrap;
+    opacity: 0.85;
+}
+
+.tab-btn.active {
+    opacity: 1;
+    border-bottom: 2px solid #111;
+}
+
+.perf-card {
+    width: 100%;
+    background: #dcdcdc;
+    border-radius: 8px;
+    aspect-ratio: 3 / 4;
+}

--- a/src/main/resources/static/js/performance/detail.js
+++ b/src/main/resources/static/js/performance/detail.js
@@ -1,0 +1,55 @@
+$(function () {
+    const performanceId = $("#performanceId").val();
+
+    function escapeHtml(str) {
+        return String(str)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#039;");
+    }
+
+    function renderDetail(d) {
+        const title = d?.title ?? "-";
+        const status = d?.status ?? "-";
+        const capacity = d?.capacity ?? "-";
+        const description = d?.description ?? "-";
+
+        $("#detailWrap").html(`
+            <h4 class="mb-2">${escapeHtml(title)}</h4>
+            <div class="mb-2">
+                <span class="badge text-bg-secondary">${escapeHtml(status)}</span>
+                <span class="ms-2 text-muted">정원: ${escapeHtml(capacity)}</span>
+            </div>
+            <hr/>
+            <div class="small text-muted mb-1">설명</div>
+            <div>${escapeHtml(description)}</div>
+        `);
+    }
+
+    function loadDetail() {
+        $.ajax({
+            url: `/api/performances/${performanceId}`,
+            method: "GET",
+            dataType: "json",
+        })
+            .done(function (res) {
+                const data = res?.data;
+
+                if (!data) {
+                    console.error("[performance detail] data 없음", res);
+                    $("#detailWrap").html(`<div class="text-danger">응답 형식 오류(data 없음)</div>`);
+                    return;
+                }
+
+                renderDetail(data);
+            })
+            .fail(function (xhr) {
+                console.error("[performance detail] 상세 조회 실패", xhr);
+                $("#detailWrap").html(`<div class="text-danger">상세 조회 실패</div>`);
+            });
+    }
+
+    loadDetail();
+});

--- a/src/main/resources/static/js/performance/list.js
+++ b/src/main/resources/static/js/performance/list.js
@@ -1,0 +1,124 @@
+$(function () {
+    const state = {
+        page: 0,
+        size: 9,
+        keyword: "",
+        category: "",
+        filter: "",
+        loading: false,
+        last: false
+    };
+
+    function escapeHtml(str) {
+        return String(str)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#039;");
+    }
+
+    function renderCards(items, append) {
+        if (!append) {
+            $("#performanceGrid").empty();
+        }
+
+        items.forEach(function (p) {
+            const id = p.performanceId;
+            if (!id) return;
+
+            const title = p.title ?? "공연";
+
+            const card = `
+                <div class="col-4">
+                    <a class="d-block text-decoration-none" href="/performances/${id}">
+                        <div class="perf-card"></div>
+                        <div class="mt-2 small text-dark text-truncate">${escapeHtml(title)}</div>
+                    </a>
+                </div>
+            `;
+
+            $("#performanceGrid").append(card);
+        });
+    }
+
+    function fetchList(append) {
+        if (state.loading || state.last) {
+            return;
+        }
+
+        state.loading = true;
+
+        $.ajax({
+            url: "/api/performances",
+            method: "GET",
+            dataType: "json",
+            data: {
+                keyword: state.keyword || null,
+                category: state.category || null,
+                page: state.page,
+                size: state.size
+            }
+        })
+            .done(function (res) {
+                const pageObj = res?.data;
+
+                if (!pageObj) {
+                    console.error("[performances] data 없음", res);
+                    alert("응답 형식 오류");
+                    return;
+                }
+
+                const items = pageObj.content || [];
+                state.last = !!pageObj.last;
+
+                renderCards(items, append);
+
+                if (!state.last) {
+                    state.page += 1;
+                }
+            })
+            .fail(function (xhr) {
+                console.error("[performances] 목록 조회 실패", xhr);
+                alert("목록 조회 실패");
+            })
+            .always(function () {
+                state.loading = false;
+            });
+    }
+
+    function resetAndLoad() {
+        state.page = 0;
+        state.last = false;
+        fetchList(false);
+    }
+
+    $("#searchBtn").on("click", function () {
+        state.keyword = $("#keyword").val().trim();
+        resetAndLoad();
+    });
+
+    $("#keyword").on("keydown", function (e) {
+        if (e.key === "Enter") {
+            $("#searchBtn").click();
+        }
+    });
+
+    $(document).on("click", ".tab-btn", function () {
+        $(".tab-btn").removeClass("active");
+        $(this).addClass("active");
+
+        const category = $(this).data("category");
+        if (typeof category !== "undefined") {
+            state.category = category || "";
+        }
+
+        resetAndLoad();
+    });
+
+    $(document).on("click", "#loadMoreBtn", function () {
+        fetchList(true);
+    });
+
+    resetAndLoad();
+});

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>공연 상세</title>
+
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+    >
+</head>
+<body>
+<div class="app-wrapper">
+    <div class="top-slot"></div>
+
+    <main class="app-main p-3">
+        <div class="d-flex align-items-center gap-2 mb-3">
+            <a
+                class="btn btn-sm btn-outline-secondary"
+                href="/performances"
+            >
+                뒤로
+            </a>
+            <h5 class="m-0">공연 상세</h5>
+        </div>
+
+        <div
+            id="detailWrap"
+            class="border rounded p-3"
+        >
+            <div class="text-muted">로딩 중...</div>
+        </div>
+
+        <!-- performanceId를 JS로 넘김 -->
+        <input
+            type="hidden"
+            id="performanceId"
+            th:value="${performanceId}"
+        />
+    </main>
+
+    <div class="bottom-slot"></div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script th:src="@{/js/performance/detail.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/performance/grid.html
+++ b/src/main/resources/templates/performance/grid.html
@@ -1,0 +1,28 @@
+<div th:fragment="grid" xmlns:th="http://www.w3.org/1999/xhtml">
+    <div id="performanceGrid" class="row g-3">
+        <div
+            class="col-4"
+            th:each="i : ${#numbers.sequence(1, 9)}"
+        >
+            <a
+                class="d-block text-decoration-none"
+                href="javascript:void(0)"
+            >
+                <div class="perf-card"></div>
+                <div class="mt-2 small text-dark text-truncate">
+                    공연명
+                </div>
+            </a>
+        </div>
+    </div>
+
+    <div class="d-flex justify-content-center mt-4">
+        <button
+            id="loadMoreBtn"
+            class="btn btn-outline-secondary"
+            type="button"
+        >
+            더보기
+        </button>
+    </div>
+</div>

--- a/src/main/resources/templates/performance/list.html
+++ b/src/main/resources/templates/performance/list.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>공연 리스트</title>
+
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+    >
+    <link
+        rel="stylesheet"
+        th:href="@{/css/performance/list.css}"
+    >
+</head>
+<body>
+<div class="app-wrapper">
+    <div class="top-slot"></div>
+
+    <main class="app-main">
+        <!-- 검색창(부트스트랩 navbar에서 form만 가져옴) -->
+        <form
+            class="d-flex mb-3"
+            role="search"
+            onsubmit="return false;"
+        >
+            <input
+                id="keyword"
+                class="form-control me-2"
+                type="search"
+                placeholder="Search"
+                aria-label="Search"
+            >
+            <button
+                id="searchBtn"
+                class="btn btn-secondary"
+                type="button"
+            >
+                Search
+            </button>
+        </form>
+
+        <!-- 핫한 공연 캐러셀(박스) + 공연등록(공연자만) -->
+        <section class="hot-carousel mb-3">
+            <div class="hot-carousel-inner">
+                <span class="hot-title">핫한 공연들 캐러셀</span>
+            </div>
+
+            <div class="text-end mt-2">
+                <a
+                    class="btn btn-sm btn-secondary"
+                    th:if="${#authorization.expression('hasRole(''PERFORMER'')')}"
+                    th:href="@{/performances/new}"
+                >
+                    공연등록
+                </a>
+            </div>
+        </section>
+
+        <!-- 탭 -->
+        <nav class="category-tabs mb-3">
+            <button
+                class="tab-btn active"
+                data-category=""
+                type="button"
+            >
+                전체
+            </button>
+            <button
+                class="tab-btn"
+                data-category="BAND"
+                type="button"
+            >
+                밴드
+            </button>
+            <button
+                class="tab-btn"
+                data-category="MUSICAL"
+                type="button"
+            >
+                뮤지컬
+            </button>
+            <button
+                class="tab-btn"
+                data-category="PLAY"
+                type="button"
+            >
+                연극
+            </button>
+            <button
+                class="tab-btn"
+                data-filter="BOOKMARK"
+                type="button"
+            >
+                북마크리스트
+            </button>
+            <button
+                class="tab-btn"
+                data-filter="VIEWED"
+                type="button"
+            >
+                본공연리스트
+            </button>
+        </nav>
+
+        <!-- 그리드 자리(초기 더미 렌더링) -->
+        <div
+            id="gridWrap"
+            th:replace="~{performance/grid :: grid}"
+        ></div>
+    </main>
+
+    <div class="bottom-slot"></div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script th:src="@{/js/performance/list.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## 📝 작업 내용

- 공연 목록 화면 레이아웃 구현하고 더미 데이터를 기반으로 렌더링 구조 구성
- 공연 상세 화면은 API 연동 테스트를 위한 임시 페이지로 구성
- 목록 → 상세 페이지 이동 흐름 연결해 화면 단위 테스트 가능하도록 함
- Closes #14 

## ✅ 셀프 체크리스트

- [x]  브랜치 전략(feature -> develop)을 준수하였는가?
- [x]  커밋 메시지 컨벤션을 지켰는가? (yyyy-MM-dd, [변경내용])
- [x]  로그(SLF4J)를 적절히 사용하였는가? (System.out 금지)
- [x]  Public 메서드에 JavaDoc 주석을 작성하였는가?
- [x]  불필요한 공백이나 사용하지 않는 Import를 제거하였는가?

## 📸 스크린샷 / 결과 (선택)

- 공연 목록 화면 및 목록 → 상세 페이지 이동 결과

<img width="225" height="650" alt="스크린샷 2026-02-05 오전 11 46 03" src="https://github.com/user-attachments/assets/2e72f498-5636-46d1-a295-8b404e1dedd9" />

헤더/푸터는 추후 적용 예정으로 빈 공간 처리

<img width="282" height="218" alt="image" src="https://github.com/user-attachments/assets/e79b5d4b-45c4-4367-bfd5-57ddae2c368c" />