### PR TITLE
2026-02-09, 공연 상세 화면 후기 탭 리뷰 조회 기능 구현, 이슈 #25 관련

### DIFF
--- a/src/main/java/com/encore/encore/domain/community/repository/ReviewRepository.java
+++ b/src/main/java/com/encore/encore/domain/community/repository/ReviewRepository.java
@@ -1,0 +1,26 @@
+package com.encore.encore.domain.community.repository;
+
+import com.encore.encore.domain.community.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    /**
+     * 특정 공연에 대한 공연 후기 목록 조회
+     * - 좌석 후기(seat_id가 존재하는 리뷰)는 제외
+     * - 작성자 정보(user)를 함께 조회하기 위해 EntityGraph를 사용(N+1 쿼리 방지 목적)
+     * - 페이징 처리를 지원
+     *
+     * @param performanceId 공연 ID
+     * @param pageable 페이징 정보
+     * @return 공연 후기 페이지
+     */
+    @EntityGraph(attributePaths = {"user"})
+    Page<Review> findByPerformance_PerformanceIdAndSeatIsNull(
+        Long performanceId,
+        Pageable pageable
+    );
+}

--- a/src/main/java/com/encore/encore/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/encore/encore/domain/performance/controller/PerformanceController.java
@@ -2,6 +2,7 @@ package com.encore.encore.domain.performance.controller;
 
 import com.encore.encore.domain.performance.dto.PerformanceDetailDto;
 import com.encore.encore.domain.performance.dto.PerformanceListItemDto;
+import com.encore.encore.domain.performance.dto.PerformanceReviewItemDto;
 import com.encore.encore.domain.performance.service.PerformanceService;
 import com.encore.encore.global.common.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +70,20 @@ public class PerformanceController {
         return CommonResponse.ok(
             performanceService.getHotPerformances(),
             "핫한 공연 조회 성공"
+        );
+    }
+
+    @GetMapping("/{performanceId}/reviews")
+    public CommonResponse<Page<PerformanceReviewItemDto>> getPerformanceReviews(
+        @PathVariable Long performanceId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        log.info("[Performance] controller reviews - performanceId={}, page={}, size={}", performanceId, page, size);
+
+        return CommonResponse.ok(
+            performanceService.getPerformanceReviews(performanceId, PageRequest.of(page, size)),
+            "공연 리뷰 조회 성공"
         );
     }
 }

--- a/src/main/java/com/encore/encore/domain/performance/dto/PerformanceReviewItemDto.java
+++ b/src/main/java/com/encore/encore/domain/performance/dto/PerformanceReviewItemDto.java
@@ -1,0 +1,24 @@
+package com.encore.encore.domain.performance.dto;
+
+import com.encore.encore.domain.community.entity.Review;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PerformanceReviewItemDto {
+
+    private final Long reviewId;
+    private final String nickname;
+    private final Integer rating;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    public PerformanceReviewItemDto(Review review) {
+        this.reviewId = review.getReviewId();
+        this.nickname = review.getUser() != null ? review.getUser().getNickname() : "-";
+        this.rating = review.getRating();
+        this.content = review.getContent();
+        this.createdAt = review.getCreatedAt();
+    }
+}

--- a/src/main/java/com/encore/encore/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/encore/encore/domain/performance/service/PerformanceService.java
@@ -1,7 +1,9 @@
 package com.encore.encore.domain.performance.service;
 
+import com.encore.encore.domain.community.repository.ReviewRepository;
 import com.encore.encore.domain.performance.dto.PerformanceDetailDto;
 import com.encore.encore.domain.performance.dto.PerformanceListItemDto;
+import com.encore.encore.domain.performance.dto.PerformanceReviewItemDto;
 import com.encore.encore.domain.performance.entity.Performance;
 import com.encore.encore.domain.performance.repository.PerformanceRepository;
 import com.encore.encore.global.error.ApiException;
@@ -21,6 +23,7 @@ import java.util.List;
 public class PerformanceService {
 
     private final PerformanceRepository performanceRepository;
+    private final ReviewRepository reviewRepository;
 
     /**
      * 공연 목록 조회 (검색/카테고리/페이징 지원)
@@ -103,5 +106,29 @@ public class PerformanceService {
 
         log.info("[Performance] hot list result - size={}", result.size());
         return result;
+    }
+
+    /**
+     * 공연에 대한 후기 목록 조회
+     * - 좌석 후기(seat_id가 있는 리뷰)는 제외하고 공연 후기만 조회
+     * - 공연이 존재하지 않을 경우 NOT_FOUND 예외를 발생시킴
+     * - 페이징 처리를 지원
+     *
+     * @param performanceId 공연 ID
+     * @param pageable 페이징 정보
+     * @return 공연 후기 페이지(리스트 DTO)
+     * @throws ApiException 공연이 존재하지 않을 경우
+     */
+    public Page<PerformanceReviewItemDto> getPerformanceReviews(Long performanceId, Pageable pageable) {
+        if (!performanceRepository.existsById(performanceId)) {
+            throw new ApiException(
+                ErrorCode.NOT_FOUND,
+                "공연을 찾을 수 없습니다. performanceId=" + performanceId
+            );
+        }
+
+        return reviewRepository
+            .findByPerformance_PerformanceIdAndSeatIsNull(performanceId, pageable)
+            .map(PerformanceReviewItemDto::new);
     }
 }

--- a/src/main/resources/static/css/performance/detail.css
+++ b/src/main/resources/static/css/performance/detail.css
@@ -228,3 +228,113 @@ body {
 .reported-btn:active {
     transform: scale(0.96);
 }
+
+.review-summary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 18px 0 10px 0;
+}
+
+.review-summary-title {
+    font-size: 22px;
+    font-weight: 900;
+    color: #222;
+}
+
+.review-summary-rating {
+    font-size: 16px;
+    font-weight: 900;
+    color: #e53935;
+}
+
+.review-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 10px 0 10px 0;
+}
+
+.review-card {
+    background: #efefef;
+    border-radius: 22px;
+    padding: 16px 16px;
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+}
+
+.review-left {
+    flex: 1;
+    min-width: 0;
+}
+
+.review-stars {
+    font-size: 18px;
+    letter-spacing: 2px;
+    margin-bottom: 8px;
+}
+
+.review-meta {
+    font-size: 14px;
+    font-weight: 800;
+    color: #222;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.review-dot {
+    color: #999;
+    font-weight: 700;
+}
+
+.review-content {
+    font-size: 16px;
+    font-weight: 700;
+    color: #222;
+    line-height: 1.5;
+    word-break: break-word;
+}
+
+.review-right {
+    width: 88px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.review-thumb {
+    width: 78px;
+    height: 78px;
+    background: #6f6f6f;
+    border-radius: 18px;
+}
+
+/* 빈 상태 */
+.review-empty {
+    text-align: center;
+    padding: 26px 0 30px 0;
+    font-size: 14px;
+    font-weight: 700;
+    color: #777;
+}
+
+.review-more-wrap {
+    display: flex;
+    justify-content: center;
+    padding: 8px 0 18px 0;
+}
+
+.review-more-btn {
+    border: 0;
+    background: #222;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 800;
+    padding: 10px 16px;
+    border-radius: 999px;
+}
+

--- a/src/main/resources/static/js/performance/detail.js
+++ b/src/main/resources/static/js/performance/detail.js
@@ -6,6 +6,16 @@ $(function () {
     let isWatched = false;
     let isReported = false;
 
+    // 리뷰 조회 상태(중복 호출 방지 + 더보기)
+    let reviewLoaded = false;
+    let reviewPage = 0;
+    const reviewSize = 10;
+    let reviewLast = true;
+
+    // 리뷰 프리로드(평점 미리 표시용)
+    let reviewPrefetched = false;
+    let cachedReviewPage0 = null; // { content: [], last: true }
+
     function escapeHtml(str) {
         return String(str ?? "")
             .replaceAll("&", "&amp;")
@@ -25,6 +35,32 @@ $(function () {
 
             $(".tab-content").removeClass("active");
             $(`#tab-${tab}`).addClass("active");
+
+            // 공연후기 탭 진입 시 리뷰 조회
+            if (tab === "review" && !reviewLoaded) {
+                // 캐시가 있으면 API 재호출 없이 바로 렌더
+                if (cachedReviewPage0) {
+                    renderReviews(cachedReviewPage0.content, true);
+
+                    // 더보기 버튼 처리
+                    reviewLast = cachedReviewPage0.last;
+                    reviewLoaded = true;
+
+                    if (!reviewLast) {
+                        $("#reviewMoreWrap").show();
+                    } else {
+                        $("#reviewMoreWrap").hide();
+                    }
+
+                    // 빈 상태 처리
+                    if (!cachedReviewPage0.content || cachedReviewPage0.content.length === 0) {
+                        $("#reviewEmpty").show();
+                    }
+                } else {
+                    // 캐시 없으면 기존대로 호출
+                    loadReviews(true);
+                }
+            }
         });
     }
 
@@ -104,7 +140,6 @@ $(function () {
         const title = d?.title ?? "공연 제목";
         const description = d?.description ?? "공연상세설명";
         const status = d?.status ?? "-";
-        const capacity = d?.capacity ?? null;
 
         // 상단 카테고리 텍스트
         $("#categoryText").text(statusToCategory(status));
@@ -117,14 +152,13 @@ $(function () {
         const address = d?.address ?? "-";
         $("#metaText").text(`${address} · ${venueName}`);
 
-        // 평점(현재 DTO에 없음)
+        // 평점(초기)
         $("#ratingText").text("-");
 
         // 상세설명
         $("#descText").text(escapeHtml(description));
 
         // 초기 UI 상태(현재는 기본 off)
-        // 나중에 서버에서 wish/watched/reported 여부 내려주면 여기 변경 예정
         setWishUI(isWished);
         setWatchedUI(isWatched);
         setReportedUI(isReported);
@@ -156,6 +190,172 @@ $(function () {
             });
     }
 
+    // 리뷰 카드 HTML 생성
+    function buildReviewCard(r) {
+        const nickname = escapeHtml(r?.nickname ?? "-");
+        const rating = Number(r?.rating ?? 0);
+        const content = escapeHtml(r?.content ?? "");
+        const createdAt = escapeHtml(
+            (r?.createdAt ?? "")
+                .replace("T", " ")
+                .substring(0, 16) // YYYY-MM-DD HH:mm
+        );
+
+        // 별점(5개)
+        const stars = Array.from({ length: 5 }, (_, i) => (i < rating ? "★" : "☆")).join("");
+
+        return `
+            <div class="review-card">
+                <div class="review-left">
+                    <div class="review-stars">${stars}</div>
+                    <div class="review-meta">
+                        <span class="review-nickname">${nickname}</span>
+                        <span class="review-dot">·</span>
+                        <span class="review-date">${createdAt}</span>
+                    </div>
+                    <div class="review-content">${content}</div>
+                </div>
+                <div class="review-right">
+                    <div class="review-thumb"></div>
+                </div>
+            </div>
+        `;
+    }
+
+    // 평균 평점 계산(현재 페이지 기준)
+    function calcAvgRating(items) {
+        if (!items || items.length === 0) return null;
+
+        const sum = items.reduce((acc, cur) => acc + Number(cur?.rating ?? 0), 0);
+        return sum / items.length;
+    }
+
+    // 탭 버튼 옆 평점 업데이트
+    function setAvgRatingUI(avg) {
+        if (avg == null) {
+            $("#ratingText").text("-");
+            return;
+        }
+
+        $("#ratingText").text(avg.toFixed(1));
+    }
+
+    // 리뷰 목록 렌더
+    function renderReviews(content, reset) {
+        const $list = $("#reviewList");
+
+        if (reset) {
+            $list.empty();
+            $("#reviewEmpty").hide();
+        }
+
+        if (!content || content.length === 0) {
+            if (reset) {
+                $("#reviewEmpty").show();
+            }
+            return;
+        }
+
+        const html = content.map(buildReviewCard).join("");
+        $list.append(html);
+    }
+
+    // 리뷰 조회
+    function loadReviews(reset) {
+        // reset=true면 첫 페이지부터 다시
+        if (reset) {
+            reviewPage = 0;
+            reviewLast = true;
+            reviewLoaded = false;
+            $("#reviewMoreWrap").hide();
+            $("#reviewEmpty").hide();
+            $("#reviewList").empty();
+        }
+
+        $.ajax({
+            url: `/api/performances/${performanceId}/reviews`,
+            method: "GET",
+            dataType: "json",
+            data: {
+                page: reviewPage,
+                size: reviewSize,
+            },
+        })
+            .done(function (res) {
+                const pageData = res?.data;
+
+                if (!pageData) {
+                    console.error("[reviews] data 없음", res);
+                    $("#reviewEmpty").show().text("응답 형식 오류(data 없음)");
+                    return;
+                }
+
+                const content = pageData?.content ?? [];
+                const last = !!pageData?.last;
+
+                // 평균 평점(현재는 1페이지 기준)
+                const avg = calcAvgRating(content);
+                setAvgRatingUI(avg);
+
+                // 리스트 렌더
+                renderReviews(content, reset);
+
+                // 더보기 상태
+                reviewLast = last;
+                reviewLoaded = true;
+
+                if (!reviewLast) {
+                    $("#reviewMoreWrap").show();
+                } else {
+                    $("#reviewMoreWrap").hide();
+                }
+            })
+            .fail(function (xhr) {
+                console.error("[reviews] 조회 실패", xhr);
+                $("#reviewEmpty").show().text("후기 조회 실패");
+            });
+    }
+
+    // 페이지 진입 시 - 공연후기 탭 버튼 옆 평점만 미리 세팅
+    function preloadReviewRating() {
+        if (reviewPrefetched) return;
+
+        $.ajax({
+            url: `/api/performances/${performanceId}/reviews`,
+            method: "GET",
+            dataType: "json",
+            data: { page: 0, size: reviewSize },
+        })
+            .done(function (res) {
+                const pageData = res?.data;
+                if (!pageData) return;
+
+                const content = pageData?.content ?? [];
+                const last = !!pageData?.last;
+
+                // 평균 평점 (현재는 1페이지 기준)
+                const avg = calcAvgRating(content);
+                setAvgRatingUI(avg);
+
+                // 0페이지 캐싱(탭 들어갔을 때 바로 리스트 뿌리기)
+                cachedReviewPage0 = { content, last };
+
+                reviewPrefetched = true;
+            })
+            .fail(function () {
+                setAvgRatingUI(null);
+            });
+    }
+
+    // 더보기 버튼
+    $("#reviewMoreBtn").off("click").on("click", function () {
+        if (reviewLast) return;
+
+        reviewPage += 1;
+        loadReviews(false);
+    });
+
     bindTabs();
     loadDetail();
+    preloadReviewRating();
 });

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -85,9 +85,17 @@
                 </div>
 
                 <div id="tab-review" class="tab-content">
-                    <div class="placeholder-center">
-                        <div class="placeholder-title">공연후기</div>
-                        <div class="placeholder-sub">후기 리스트/작성 UI 붙일 자리</div>
+                    <!-- 후기 리스트 -->
+                    <div class="review-list" id="reviewList"></div>
+
+                    <!-- 페이징 -->
+                    <div class="review-more-wrap" id="reviewMoreWrap" style="display:none;">
+                        <button type="button" class="review-more-btn" id="reviewMoreBtn">더보기</button>
+                    </div>
+
+                    <!-- 빈 상태 -->
+                    <div class="review-empty" id="reviewEmpty" style="display:none;">
+                        아직 등록된 후기가 없어요
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 📝 작업 내용

- 공연 리뷰 조회 API 구현
- 공연 상세 화면 후기 탭 UI 구성
- 후기 탭 진입 시 리뷰 조회 API 호출 및 리스트 렌더링
- 등록된 후기가 없는 경우 빈 상태 UI 처리
- Closes #25 

## ✅ 셀프 체크리스트

- [x]  브랜치 전략(feature -> develop)을 준수하였는가?
- [x]  커밋 메시지 컨벤션을 지켰는가? (yyyy-MM-dd, [변경내용])
- [x]  로그(SLF4J)를 적절히 사용하였는가? (System.out 금지)
- [x]  Public 메서드에 JavaDoc 주석을 작성하였는가?
- [x]  불필요한 공백이나 사용하지 않는 Import를 제거하였는가?

## 📸 스크린샷 / 결과 (선택)

- UI 변경이 있거나 API 테스트 결과가 있다면 첨부해 주세요.
<img width="489" height="400" alt="image" src="https://github.com/user-attachments/assets/e5ae75c6-f915-440c-854a-03549972aa4e" />
<br/>
<img width="220" height="664" alt="image" src="https://github.com/user-attachments/assets/d1e19322-0b80-45a3-9e13-3abdc357bfc6" />
<img width="224" height="665" alt="image" src="https://github.com/user-attachments/assets/1e845792-f64f-46b9-aaeb-a05f13534614" />
<img width="223" height="664" alt="image" src="https://github.com/user-attachments/assets/7c9b3796-4e9f-4988-a202-ceac9e4875ef" />
