### PR TITLE
2026-03-04, 피드 팔로우 프로필 연동 및 공연상세 신고 연결, 이슈 #69 관련

### DIFF
--- a/src/main/java/com/encore/encore/domain/community/entity/ReportTargetType.java
+++ b/src/main/java/com/encore/encore/domain/community/entity/ReportTargetType.java
@@ -8,6 +8,7 @@ public enum ReportTargetType {
     ROLE_PERFORMER("공연자"),
     ROLE_HOST("공연장 호스트"),
     VENUE("공연장"),
+    PERFORMANCE("공연"),
     CHAT_ROOM("채팅방"),
     PERFORMER_PARTY("공연자 파티"),
     DM("DM");

--- a/src/main/java/com/encore/encore/domain/community/repository/ReportRepository.java
+++ b/src/main/java/com/encore/encore/domain/community/repository/ReportRepository.java
@@ -1,7 +1,14 @@
 package com.encore.encore.domain.community.repository;
 
 import com.encore.encore.domain.community.entity.Report;
+import com.encore.encore.domain.community.entity.ReportTargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByReporter_UserIdAndTargetIdAndTargetTypeAndIsDeletedFalse(
+        Long userId,
+        Long targetId,
+        ReportTargetType targetType
+    );
 }

--- a/src/main/java/com/encore/encore/domain/member/controller/MemberPageController.java
+++ b/src/main/java/com/encore/encore/domain/member/controller/MemberPageController.java
@@ -83,4 +83,17 @@ public class MemberPageController {
 
         return "member/memberProfile";
     }
+
+    @GetMapping("member/profile/u/{userId}")
+    public String memberProfileByUserId(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long userId,
+        Model model
+    ) {
+        Long profileId = memberService.getDefaultProfileIdByUserId(userId);
+
+        String profileMode = ActiveMode.ROLE_USER.name();
+
+        return memberProfile(userDetails, profileId, profileMode, model);
+    }
 }

--- a/src/main/java/com/encore/encore/domain/member/service/MemberService.java
+++ b/src/main/java/com/encore/encore/domain/member/service/MemberService.java
@@ -258,4 +258,18 @@ public class MemberService {
         return recentActivitiesDtoList;
 
     }
+
+    /**
+     * userId로 기본 USER 프로필의 profileId 조회
+     */
+    public Long getDefaultProfileIdByUserId(Long userId) {
+
+        UserProfile userProfile = userProfileRepository.findByUser_UserId(userId)
+            .orElseThrow(() -> new ApiException(
+                ErrorCode.NOT_FOUND,
+                "유저 프로필을 찾을 수 없습니다. userId=" + userId
+            ));
+
+        return userProfile.getProfileId();
+    }
 }

--- a/src/main/java/com/encore/encore/domain/performance/controller/UserPerformanceRelationController.java
+++ b/src/main/java/com/encore/encore/domain/performance/controller/UserPerformanceRelationController.java
@@ -206,4 +206,22 @@ public class UserPerformanceRelationController {
             "북마크(찜) 공연 목록 조회 성공"
         );
     }
+
+    @GetMapping("/{performanceId}/reported")
+    public CommonResponse<Map<String, Object>> isReported(
+        @PathVariable Long performanceId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            log.info("[UserPerformanceRelation] controller isReported - anonymous, performanceId={}", performanceId);
+            return CommonResponse.ok(Map.of("reported", false), "비로그인: 신고 여부 false");
+        }
+
+        Long userId = userDetails.getUser().getUserId();
+        log.info("[UserPerformanceRelation] controller isReported - anonymous, performanceId={}", performanceId);
+
+        boolean reported = userPerformanceRelationService.isReported(userId, performanceId);
+
+        return CommonResponse.ok(Map.of("reported", reported), "신고 여부 조회 성공");
+    }
 }

--- a/src/main/java/com/encore/encore/domain/performance/service/UserPerformanceRelationService.java
+++ b/src/main/java/com/encore/encore/domain/performance/service/UserPerformanceRelationService.java
@@ -1,5 +1,7 @@
 package com.encore.encore.domain.performance.service;
 
+import com.encore.encore.domain.community.entity.ReportTargetType;
+import com.encore.encore.domain.community.repository.ReportRepository;
 import com.encore.encore.domain.performance.dto.PerformanceListItemDto;
 import com.encore.encore.domain.performance.entity.Performance;
 import com.encore.encore.domain.performance.entity.UserPerformanceRelation;
@@ -25,6 +27,7 @@ public class UserPerformanceRelationService {
 
     private final UserPerformanceRelationRepository userPerformanceRelationRepository;
     private final PerformanceRepository performanceRepository;
+    private final ReportRepository reportRepository;
 
     public boolean isWatched(Long userId, Long performanceId) {
         log.info("[UserPerformanceRelation] isWatched request - userId={}, performanceId={}", userId, performanceId);
@@ -131,5 +134,14 @@ public class UserPerformanceRelationService {
             .findPerformancesByUserIdAndStatusAndKeywordOrderByCreatedAtDesc(userId, WISHED, keyword, pageable);
 
         return page.map(PerformanceListItemDto::new);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isReported(Long userId, Long performanceId) {
+        return reportRepository.existsByReporter_UserIdAndTargetIdAndTargetTypeAndIsDeletedFalse(
+            userId,
+            performanceId,
+            ReportTargetType.PERFORMANCE
+        );
     }
 }

--- a/src/main/resources/static/js/feed/list.js
+++ b/src/main/resources/static/js/feed/list.js
@@ -69,7 +69,6 @@ function createFeedCard(item) {
     const startDate = parseIsoLocalDateTime(startTime);
     const timeText = startDate ? formatKoreanDateTime(startDate) : "시간 정보 없음";
 
-    // type에 따라 뱃지/서브텍스트 다르게
     const { badgeText, subText } = buildLabels(item);
 
     const card = document.createElement("div");
@@ -79,10 +78,12 @@ function createFeedCard(item) {
     badge.className = "feed-badge";
     badge.textContent = badgeText;
 
+    // 공연 제목
     const titleEl = document.createElement("div");
     titleEl.className = "feed-card-title";
     titleEl.textContent = title;
 
+    // 팔로우 프로필 페이지 이동 영역
     const subEl = document.createElement("div");
     subEl.className = "feed-card-sub";
     subEl.textContent = subText;
@@ -103,22 +104,34 @@ function createFeedCard(item) {
     left.appendChild(badge);
     left.appendChild(titleEl);
     left.appendChild(subEl);
-    // FOLLOW_WISHED는 subText가 이미 메시지 역할이라 중복 방지
-    if (type !== "FOLLOW_WISHED" && message) {
-        left.appendChild(msgEl);
-    }
+
+    if (type !== "FOLLOW_WISHED" && message) left.appendChild(msgEl);
     left.appendChild(timeEl);
 
     card.appendChild(left);
     card.appendChild(right);
 
-    // 클릭 시 공연 상세로 이동
     const performanceId = item?.performanceId;
+
     if (performanceId) {
         card.style.cursor = "pointer";
         card.addEventListener("click", () => {
             window.location.href = `/performances/${performanceId}`;
-    });
+        });
+    }
+
+    if (type === "FOLLOW_WISHED") {
+        const actorUserId = item?.actorUserId;
+
+        subEl.style.cursor = "pointer";
+
+        subEl.addEventListener("click", (e) => {
+            e.stopPropagation(); // 카드 클릭 막기
+
+            if (!actorUserId) return;
+
+            window.location.href = `/member/profile/u/${actorUserId}`;
+        });
     }
 
     return card;

--- a/src/main/resources/static/js/performance/detail.js
+++ b/src/main/resources/static/js/performance/detail.js
@@ -7,6 +7,7 @@ $(function () {
     let isReported = false;
     let watchedChecked = false;
     let wishedChecked = false;
+    let reportedChecked = false;
 
     let reviewLoaded = false;
     let reviewPage = 0;
@@ -151,7 +152,16 @@ $(function () {
         });
 
         $("#reportedBtn").off("click").on("click", function () {
-            setReportedUI(!isReported);
+            const targetId = performanceId;
+            const targetType = "PERFORMANCE";
+            const targetName = $("#perfTitle").text() || "공연";
+
+            const url =
+                `/report?targetId=${encodeURIComponent(targetId)}` +
+                `&targetType=${encodeURIComponent(targetType)}` +
+                `&targetName=${encodeURIComponent(targetName)}`;
+
+            window.location.href = url;
         });
 
         $("#writeReviewBtn").off("click").on("click", function () {
@@ -278,6 +288,26 @@ $(function () {
             .fail(function () {
                 setWatchedUI(false);
                 watchedChecked = true;
+            });
+    }
+
+    function ensureReportedStatus() {
+        if (reportedChecked) return;
+
+        $.ajax({
+            url: `/api/performances/${performanceId}/reported`,
+            method: "GET",
+            dataType: "json",
+            xhrFields: { withCredentials: true }
+        })
+            .done(function (res) {
+                const reported = !!res?.data?.reported;
+                setReportedUI(reported);
+                reportedChecked = true;
+            })
+            .fail(function () {
+                setReportedUI(false);
+                reportedChecked = true;
             });
     }
 
@@ -529,6 +559,7 @@ $(function () {
 
     bindTabs();
     loadDetail();
+    ensureReportedStatus();
 
     // 탭의 평균 평점은 "전체 평균"으로 고정 표시
     loadReviewSummary();


### PR DESCRIPTION
## 📝 작업 내용

- 피드 - 팔로우가 찜한 공연 → 팔로우 프로필 이동
- 공연 상세 - 신고 연동
- Closes #69 

## ✅ 셀프 체크리스트

- [x]  브랜치 전략(feature -> develop)을 준수하였는가?
- [x]  커밋 메시지 컨벤션을 지켰는가? (yyyy-MM-dd, [변경내용])
- [x]  로그(SLF4J)를 적절히 사용하였는가? (System.out 금지)
- [x]  Public 메서드에 JavaDoc 주석을 작성하였는가?
- [x]  불필요한 공백이나 사용하지 않는 Import를 제거하였는가?

## 📸 스크린샷 / 결과 (선택)

- UI 변경이 있거나 API 테스트 결과가 있다면 첨부해 주세요.

<img width="225" height="206" alt="피드" src="https://github.com/user-attachments/assets/17f00b9c-7577-486d-8345-3f8271c571a6" />
<br/>
공연 제목 클릭 시 공연 상세 페이지 이동, <br/>
팔로우 클릭 시 팔로우 프로필 페이지 이동
<br/>
<br/>
<img width="227" height="585" alt="밴드 공연 테스트3" src="https://github.com/user-attachments/assets/920862e6-8a12-4abc-91e2-bc917df5e68f" />
<img width="227" height="585" alt="밴드 공연 테스트3" src="https://github.com/user-attachments/assets/8c3892f6-cf48-43b3-8028-36cbf3abc49c" />
<br/>
공연 신고 기능 연결 완료 <br/>
신고 여부에 따라 신고 버튼 상태(on/off) 처리